### PR TITLE
feat: custom支持自定义类型

### DIFF
--- a/DCloud/luch-request/index.d.ts
+++ b/DCloud/luch-request/index.d.ts
@@ -26,7 +26,7 @@ export type HttpData = Record<string, any>;
 
 export type HttpResponseType = 'arraybuffer' | 'text';
 
-export type HttpCustom = Record<string, any>;
+export interface HttpCustom extends AnyObject {}
 
 export type HttpFileType = 'image' | 'video' | 'audio';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luch-request",
-  "version": "3.0.7",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "luch-request",
-      "version": "3.0.7",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@dcloudio/types": "^2.0.16"
@@ -29,6 +29,7 @@
         "grunt-babel": "^8.0.0",
         "load-grunt-tasks": "^5.1.0",
         "node-zip": "^1.1.1",
+        "rollup": "^2.66.1",
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-commonjs": "^10.1.0",
         "rollup-plugin-copy": "^3.3.0",
@@ -14653,6 +14654,21 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/rollup-plugin-babel": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
@@ -14978,6 +14994,20 @@
       "dev": true,
       "dependencies": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/run-async": {
@@ -30870,6 +30900,24 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rollup": {
+      "version": "2.79.1",
+      "resolved": "https://registry.npmmirror.com/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+          "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "rollup-plugin-babel": {

--- a/src/lib/luch-request.d.ts
+++ b/src/lib/luch-request.d.ts
@@ -26,7 +26,7 @@ export type HttpData = Record<string, any>;
 
 export type HttpResponseType = 'arraybuffer' | 'text';
 
-export type HttpCustom = Record<string, any>;
+export interface HttpCustom extends AnyObject {}
 
 export type HttpFileType = 'image' | 'video' | 'audio';
 


### PR DESCRIPTION
我想给custom参数加一些类型提示，但是发现是用type定义的类型所以无法扩展
![image](https://github.com/lei-mu/luch-request/assets/52436248/4596f2f9-9334-44fa-87cc-f89480674237)
改成用interface后就可以方便地在项目中给custom加上类型提示
![image](https://github.com/lei-mu/luch-request/assets/52436248/22fc9b49-355c-425e-a70c-2ad37b8ea5ac)
![image](https://github.com/lei-mu/luch-request/assets/52436248/8d4b4804-29cf-465e-84cb-5214eeefa92c)
