### PR TITLE
feat: :sparkles: 修改类型声明中的HttpCustom为interface，以方便支持自定义，实现全局语法提示

### DIFF
--- a/src/lib/luch-request.d.ts
+++ b/src/lib/luch-request.d.ts
@@ -26,7 +26,9 @@ export type HttpData = Record<string, any>;
 
 export type HttpResponseType = 'arraybuffer' | 'text';
 
-export type HttpCustom = Record<string, any>;
+export interface HttpCustom {
+    [key: string]: any
+};
 
 export type HttpFileType = 'image' | 'video' | 'audio';
 

--- a/test/types-test.ts
+++ b/test/types-test.ts
@@ -1,12 +1,22 @@
 import LuchRequest from "../src/lib/luch-request"
 const luchRequest = new LuchRequest();
 
+declare module '../src/lib/luch-request' {
+  export interface HttpCustom {
+    key?: string;
+    options?: unknown;
+  }
+}
+
 luchRequest.setConfig(config => {
   return config
 })
 luchRequest.post("url", { 123: 60 }, {
-  baseURL: "/api"
-}).then(response=>{
+  baseURL: "/api",
+  custom: {
+    key: '123'
+  }
+}).then(response => {
   response.config
 })
 // LuchRequestAbstract


### PR DESCRIPTION
修改了类型声明中的HttpCustom为interface，方便用户自定义覆写该类型，以实现全局的语法提示，如下图：（原类型为type，无法进行覆写）

![1](https://github.com/user-attachments/assets/d1fe00ea-b7b0-48a3-b480-892a442240d9)
![2](https://github.com/user-attachments/assets/7660ad8a-2a1a-4bc2-9d53-5ee2423db17c)
