### PR TITLE
feat: http.delete 和 http.options 支持在鸿蒙应用中使用

### DIFF
--- a/DCloud/luch-request/core/Request.js
+++ b/DCloud/luch-request/core/Request.js
@@ -115,7 +115,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   delete(url, data, options = {}) {
     return this.middleware({
       url,
@@ -151,7 +151,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   options(url, data, options = {}) {
     return this.middleware({
       url,

--- a/example/request-demo/utils/luch-request/core/Request.js
+++ b/example/request-demo/utils/luch-request/core/Request.js
@@ -115,7 +115,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   delete(url, data, options = {}) {
     return this.middleware({
       url,
@@ -151,7 +151,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   options(url, data, options = {}) {
     return this.middleware({
       url,

--- a/src/lib/core/Request.js
+++ b/src/lib/core/Request.js
@@ -115,7 +115,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   delete(url, data, options = {}) {
     return this.middleware({
       url,
@@ -151,7 +151,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   options(url, data, options = {}) {
     return this.middleware({
       url,

--- a/test/dev-test/utils/luch-request/core/Request.js
+++ b/test/dev-test/utils/luch-request/core/Request.js
@@ -115,7 +115,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   delete(url, data, options = {}) {
     return this.middleware({
       url,
@@ -151,7 +151,7 @@ export default class Request {
 
   // #endif
 
-  // #ifdef APP-PLUS || H5 || MP-WEIXIN || MP-BAIDU
+  // #ifdef APP-PLUS || APP-HARMONY || H5 || MP-WEIXIN || MP-BAIDU
   options(url, data, options = {}) {
     return this.middleware({
       url,


### PR DESCRIPTION
在鸿蒙应用中使用  http.delete 和 http.options, 都提示 undefined，需要在鸿蒙应用中添加支持

上面的http.delete 和 http.options已经在鸿蒙手机应用测试通过，能正常使用